### PR TITLE
Changes require due to limitations on js-interop in dart2js

### DIFF
--- a/lib/src/js_interop.dart
+++ b/lib/src/js_interop.dart
@@ -6,13 +6,11 @@
 @JS()
 library web_worker_channel.src.js;
 
+import 'dart:html' show Event;
 import 'package:js/js.dart';
 
-/// Base browser interface for events.
-///
-/// https://developer.mozilla.org/en-US/docs/Web/API/Event
-@JS('Event')
-abstract class Event {}
+export 'dart:html' show Event, MessageEvent;
+export 'package:js/js.dart' show allowInterop;
 
 /// Function signature for a callback that provides an [Event].
 typedef EventListener = void Function(Event);
@@ -22,21 +20,12 @@ abstract class EventTarget {
   /// Adds the specified [listener] for the event [type].
   ///
   /// TODO: Ideally type as `addEventListener<T extends Event>`.
-  external void addEventListener(String type, EventListener listener);
+  void addEventListener(String type, EventListener listener);
 
   /// Removes the specified [listener] for the event [type].
   ///
   /// TODO: Ideally type as `removeEventListener<T extends Event>`.
-  external void removeEventListener(String type, EventListener listener);
-}
-
-/// Browser interface for a `'message'` event that provides [data].
-///
-/// https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent
-@JS('MessageEvent')
-abstract class MessageEvent extends Event {
-  /// The data sent by the message emitter.
-  Object get data;
+  void removeEventListener(String type, EventListener listener);
 }
 
 /// Dart interface for any class that provides a `postMessage` API.
@@ -52,7 +41,7 @@ abstract class HasPostMessage {
 
 /// https://developer.mozilla.org/en-US/docs/Web/API/Worker
 @JS('Worker')
-abstract class Worker extends Object with EventTarget, HasPostMessage {
+abstract class Worker implements EventTarget, HasPostMessage {
   /// Creates a [Worker].
   ///
   /// [url]: Represents the URL of the script the worker will execute.
@@ -72,7 +61,16 @@ abstract class Worker extends Object with EventTarget, HasPostMessage {
 /// Window object (or window context in a web worker).
 @JS()
 @anonymous
-abstract class Self extends Object with EventTarget, HasPostMessage {}
+abstract class Self implements EventTarget, HasPostMessage {
+  @override
+  external void addEventListener(String type, EventListener listener);
+
+  @override
+  external void removeEventListener(String type, EventListener listener);
+
+  @override
+  external void postMessage(Object message);
+}
 
 /// Window object (or window context in a web worker).
 @JS()

--- a/lib/web_worker_channel.dart
+++ b/lib/web_worker_channel.dart
@@ -27,9 +27,9 @@ abstract class _PostMessageChannel extends StreamChannelMixin<Object> {
   final _onMessage = new StreamController<Object>(sync: true);
 
   _PostMessageChannel() {
-    final onMessage = Zone.current.bindUnaryCallback((Event e) {
+    final onMessage = allowInterop(Zone.current.bindUnaryCallback((Event e) {
       _onMessage.add((e as MessageEvent).data);
-    });
+    }));
     registerListener(onMessage);
     sink.stream.listen((message) {
       sendPostMessage(message);


### PR DESCRIPTION
After some other fixes in dart2js, I had to make some modifications to the example to be able to workaround other js-interop bugs.

One bug relates to using mixins in jsinterop, it simply doesn't work in dart2js, see https://github.com/dart-lang/sdk/issues/33065

Removing Event/MessageEvent is necessary at this moment because the html library mappings for these types are causing conflict with the ones you define in jsinterop. I hope we can fix this in a better way, but just using the html types here is a simple way to unblock things.

